### PR TITLE
adds a routine for adding missing entries in the variable metadata json

### DIFF
--- a/production_scripts/metadata_consistency/check_variable_metadata_consistency.py
+++ b/production_scripts/metadata_consistency/check_variable_metadata_consistency.py
@@ -4,7 +4,7 @@ import argparse
 def check_keys_consistency(json_file, optional_keys=None):
     # Set default optional keys
     if optional_keys is None:
-        optional_keys = set(['standard_name', 'internal note', 'GCMD_keywords'])
+        optional_keys = set(['standard_name', 'internal note'])
     else:
         optional_keys = set(optional_keys)
 

--- a/production_scripts/metadata_consistency/variable_metadata_json_bandaid.py
+++ b/production_scripts/metadata_consistency/variable_metadata_json_bandaid.py
@@ -1,0 +1,75 @@
+
+# This program adds default empty strings
+# to variable metadata entries if they
+# are missing. The defaults are all empty
+# string with the exception of 
+# coverage_content_type, which is modelResult
+
+# if entries are missing the really important
+# entries:
+# 'name'
+# 'long name'
+# 'units'
+# 'grid_dimension'
+# 'grid_location'
+
+# then you've got bigger problems 
+ 
+
+import json
+import sys
+from collections import OrderedDict
+
+# Desired key order (based on your example)
+ordered_keys = [
+    "name",
+    "long_name",
+    "units",
+    "comments_1",
+    "comments_2",
+    "direction",
+    "GCMD_keywords",
+    "grid_dimension",
+    "grid_location",
+    "coverage_content_type"
+]
+
+# Default values for missing fields
+default_fields = {
+    "name": "",
+    "long_name": "",
+    "units": "",
+    "comments_1": "",
+    "comments_2": "",
+    "direction": "",
+    "GCMD_keywords": "",
+    "grid_dimension": "",
+    "grid_location": "",
+    "coverage_content_type": "modelResult"
+}
+
+# Usage
+if len(sys.argv) != 3:
+    print("Usage: python update_json_fields_ordered.py input.json output.json")
+    sys.exit(1)
+
+input_file = sys.argv[1]
+output_file = sys.argv[2]
+
+# Load input
+with open(input_file, "r") as f:
+    data = json.load(f)
+
+# Construct entries with required key order and defaults
+new_data = []
+for entry in data:
+    new_entry = OrderedDict()
+    for key in ordered_keys:
+        new_entry[key] = entry.get(key, default_fields[key])
+
+    new_data.append(new_entry)
+
+# Save output with pretty formatting
+with open(output_file, "w") as f:
+    json.dump(new_data, f, indent=3)
+


### PR DESCRIPTION
adds 'GCMD_keywords' to the list of required keys in 'check_variable_metadata_consistency'
now the only optional keys are 'standard name' and 'internal note'.


the 'variable_metadata_json_bandaid' adds missing required keys to a variable_metadata.json
file. all empty strings except     "coverage_content_type": "modelResult"

a bandaid to add the missing entries from Hong