### PR TITLE
as per Dean H. request, change snapshot time coverage duration from P…

### DIFF
--- a/production_src/src/ecco_dataset_production/utils/gen_netcdf_utils.py
+++ b/production_src/src/ecco_dataset_production/utils/gen_netcdf_utils.py
@@ -988,8 +988,8 @@ def set_metadata(ecco,
 
     # --- SNAPSHOT
     elif output_freq_code == 'SNAPSHOT':
-        G.attrs['time_coverage_duration'] = 'P0S'
-        G.attrs['time_coverage_resolution'] = 'P0S'
+        G.attrs['time_coverage_duration'] = 'PT0S'
+        G.attrs['time_coverage_resolution'] = 'PT0S'
 
         G.time.attrs.pop('bounds')
 


### PR DESCRIPTION
as per Dean H. request, change snapshot time coverage duration from P0S to PT0S.  Both mean 'period 0 seconds', in other words instantaneous.  

The addition of the "T" in PT0S clarifies that the time unit "S" is seconds.  